### PR TITLE
Remove all non-RFC tree algorithms

### DIFF
--- a/draft-steele-cose-merkle-tree-proofs.md
+++ b/draft-steele-cose-merkle-tree-proofs.md
@@ -208,93 +208,20 @@ This document establishes a registry of Merkle tree algorithms with the followin
 | Name              | Label | Description
 |---
 |Reserved           | 0     |
-|CCF_SHA256         | 1     | CCF with SHA-256
-|RFC6962_SHA256     | 2     | RFC6962 with SHA-256
-|RFC6962_BL_SHA256  | 3     | RFC6962 with blinding and SHA-256
-|QLDB_SHA256        | 4     | QLDB with SHA-256
-|OZ_Keccak256       | 5     | Open Zeppelin with keccak256
+|RFC9162_SHA256     | 1     | RFC9162 with SHA-256
 {: align="left" title="Merke Tree Alogrithms"}
 
 Each tree algorithm defines how to compute the root node from a sequence of leaves each represented by payload and extra data. Extra data is algorithm-specific and should be considered opaque.
 
-## CCF_SHA256
+## RFC9162_SHA256
 
-For n > 1 inputs, let k be the largest power of two smaller than n.
-
-~~~~
-MTH({d(0)}) = SHA-256(d(0))
-MTH(D[n]) = SHA-256(MTH(D[0:k]) || MTH(D[k:n]))
-~~~~
-
-where `d(0)` is computed as:
-
-~~~~ cddl
-d(0) = writeset_digest || SHA-256(commit_evidence) || SHA-256(payload)
-~~~~
-
-with extra data defined as:
-
-~~~~ cddl
-ExtraData = bstr .cbor [
-    writeset_digest: bstr .size 32
-    commit_evidence: bstr
-]
-~~~~
-
-## RFC6962_SHA256
+The `RFC9162_SHA256` tree algorithm uses the Merkle tree definition from {{RFC9162}} with SHA-256 hash algorithm.
 
 For n > 1 inputs, let k be the largest power of two smaller than n.
 
 ~~~~
 MTH({d(0)}) = SHA-256(0x00 || d(0))
 MTH(D[n]) = SHA-256(0x01 || MTH(D[0:k]) || MTH(D[k:n]))
-~~~~
-
-where `d(0)` is the payload. This algorithm takes no extra data.
-
-## RFC6962_BL_SHA256
-
-For n > 1 inputs, let k be the largest power of two smaller than n.
-
-~~~~
-MTH({d(0)}) = SHA-256(0x00 || d(0))
-MTH(D[n]) = SHA-256(0x01 || MTH(D[0:k]) || MTH(D[k:n]))
-~~~~
-
-where `d(0)` is computed as:
-
-~~~~ cddl
-d(0) = nonce || payload
-~~~~
-
-with extra data defined as:
-
-~~~~ cddl
-ExtraData = bstr .size 32  ; nonce
-~~~~
-
-## QLDB_SHA256
-
-For n > 1 inputs, let k be the largest power of two smaller than n.
-
-~~~~
-MTH({d(0)}) = SHA-256(d(0))
-MTH(D[n]) = SHA-256(DOT(MTH(D[0:k]), MTH(D[k:n])))
-DOT(H1, H2) = if H1 < H2 then H1 || H2 else H2 || H1
-~~~~
-
-where `d(0)` is the payload. This algorithm takes no extra data.
-
-## OZ_keccak256
-
-For n > 1 inputs, let k be the largest power of two smaller than n.
-
-~~~~
-MTH({d(0)}) = keccak256(keccak256(d(0)))
-MTH(D[n]) = MTH2(sorted([ MTH([d]) | d in D ]))
-MTH2({h(0)}) = h(0)
-MTH2(H[n]) = keccak256(DOT(MTH2(H[0:k]), MTH2(H[k:n])))
-DOT(H1, H2) = if H1 < H2 then H1 || H2 else H2 || H1
 ~~~~
 
 where `d(0)` is the payload. This algorithm takes no extra data.


### PR DESCRIPTION
For exploration purposes, the document had a number of tree algorithms that are not specified in RFCs or similar. This PR removes them again, transferring them to PRs for further evaluation.