### PR TITLE
Add `OZ_keccak256` tree algorithm

### DIFF
--- a/draft-steele-cose-merkle-tree-proofs.md
+++ b/draft-steele-cose-merkle-tree-proofs.md
@@ -209,6 +209,7 @@ This document establishes a registry of Merkle tree algorithms with the followin
 |---
 |Reserved           | 0     |
 |RFC9162_SHA256     | 1     | RFC9162 with SHA-256
+|OZ_keccak256       | 4     | OpenZeppelin with keccak256
 {: align="left" title="Merke Tree Alogrithms"}
 
 Each tree algorithm defines how to compute the root node from a sequence of leaves each represented by payload and extra data. Extra data is algorithm-specific and should be considered opaque.
@@ -222,6 +223,22 @@ For n > 1 inputs, let k be the largest power of two smaller than n.
 ~~~~
 MTH({d(0)}) = SHA-256(0x00 || d(0))
 MTH(D[n]) = SHA-256(0x01 || MTH(D[0:k]) || MTH(D[k:n]))
+~~~~
+
+where `d(0)` is the payload. This algorithm takes no extra data.
+
+## OZ_keccak256
+
+The `OZ_keccak256` tree algorithm uses the Merkle tree definition from TBD with keccak256 (TBD REF) hash algorithm.
+
+For n > 1 inputs, let k be the largest power of two smaller than n.
+
+~~~~
+MTH({d(0)}) = keccak256(keccak256(d(0)))
+MTH(D[n]) = MTH2(sorted([ MTH([d]) | d in D ]))
+MTH2({h(0)}) = h(0)
+MTH2(H[n]) = keccak256(DOT(MTH2(H[0:k]), MTH2(H[k:n])))
+DOT(H1, H2) = if H1 < H2 then H1 || H2 else H2 || H1
 ~~~~
 
 where `d(0)` is the payload. This algorithm takes no extra data.


### PR DESCRIPTION
Informal reference:
- https://github.com/OpenZeppelin/merkle-tree#standard-merkle-trees

TODO:
- Add OpenZeppelin reference to Merkle tree definition.
- Change target branch to `main` after #2 is merged.