### PR TITLE
Focus on RFC9162 in CBOR & COSE

### DIFF
--- a/draft-steele-cose-merkle-tree-proofs.md
+++ b/draft-steele-cose-merkle-tree-proofs.md
@@ -51,6 +51,7 @@ normative:
   RFC8949:
   RFC6962: certificate-transparency-v1
   RFC9162: certificate-transparency-v2
+  RFC8152: cose
   RFC6234:
   RFC8032:
   RFC6979:
@@ -62,7 +63,10 @@ informative:
 
 --- abstract
 
-This specification describes three CBOR data structures for primary use in COSE envelopes. A format for Merkle Tree Root Signatures with metadata, a format for Inclusions Paths, and a format for disclosure of a single hadh tree leaf payload (Merkle Tree Proofs).
+This specification describes three CBOR data structures for primary use in COSE envelopes. 
+A CBOR encoding of Merkle Roots for use in COSE payloads.
+A CBOR encoding of Inclusions Proofs for use in COSE unprotected headers.
+A CBOR encoding of Consistency Proofs for use in COSE unprotected headers.
 
 --- middle
 
@@ -93,7 +97,7 @@ This document describes the three data structures necessary to use merkle proofs
 
 Leaf:
 
-: A merkle tree leaf is the cryptographic hash of a sequence of bytes that combines Leaf Payload and Extra Data.
+: A merkle tree leaf is the cryptographic hash of a sequence of bytes that combines Leaf Payload and Extra Data. 
 
 Merkle Tree:
 
@@ -116,15 +120,15 @@ The simplest case is that the leaf is the cryptographic hash of the payload with
 
 Inclusion Path:
 
-: An inclusion path enables a verifier to recompute a root, given a leaf.
+: An inclusion path enables a verifier to recompute a root, given a leaf and extra data.
 
 Inclusion Proof:
 
-: An inclusion proof is a combination of the leaf payload, extra data, inclusion path and a merkle tree root.
+: An inclusion proof is a combination of the extra data, inclusion path and a merkle tree root.
 
 Signed Inclusion Proof:
 
-: A signed inclusion proof is a combination of the leaf payload, extra data, inclusion path and signed envelope that includes a merkle root.
+: A signed inclusion proof is a combination of the inclusion path and signed envelope that includes a merkle root.
 
 # CBOR Merkle Structures
 
@@ -136,6 +140,29 @@ or an inclusion proof from a leaf to a merkle root, might have several different
 Some differences in representations are necessary to support efficient
 verification of different kinds of inclusion proofs and for compatibility with deployed tree algorithms used in specific implementations.
 
+In case of {{-certificate-transparency-v2}}, this is defined in Section 2.1.1. Definition of the Merkle Tree.
+
+## Inclusion Proof
+
+{{-certificate-transparency-v1}} defines a merkle audit path for a leaf in a merkle tree
+as the shortest list of additional nodes in the merkle tree required to compute the merkle root for that tree.
+
+{{-certificate-transparency-v2}} changed the term from "merkle audit path" to "merkle inclusion proof".
+
+We prefer to use the term "inclusion path" to avoid confusion with Signed Inclusion Proof.
+
+For tree algorithm "RFC9162_SHA256", we define the following compact encoding of an inclusion proof for a leaf:
+
+~~~~ cddl
+inclusion-proof = #6.1234([
+    tree-size: int
+    leaf-index: int
+    inclusion-path: [+ bstr]
+])
+~~~~
+
+Leaf index is also sometimes referred to as sequence number.
+
 ## Signed Inclusion Proof
 
 A Merkle root is signed with COSE_Sign1:
@@ -146,123 +173,95 @@ smtr = THIS.COSE.profile .and COSE_Sign1_Tagged
 
 Protected header parameters:
 
-* alg (label: 1): REQUIRED. Signature algorithm. Value type: int / tstr.
-* tree alg (label: TBD): REQUIRED. Merkle tree algorithm. Value type: int / tstr.
+* alg (label: 1): REQUIRED. Signature algorithm identifier. Value type: int / tstr.
+* tree_alg (label: TBD): REQUIRED. Merkle tree algorithm identifier. Value type: int / tstr.
+* crit (label: 2): REQUIRED. Criticality marker. Value type: [ +label ]
 
-A COSE profile of this specification may add further header parameters, for example to identify the signer or add a timestamp.
+The criticality header MUST contain the tree_alg label.
 
-Envelope Payload: A Merkle tree root according to the tree alg.
+The envelope payload MUST be computed by the process defined for the tree_alg.
 
-The envelope payload can be detached, since it can be recomputed by the verifier.
-
-Forcing a verifier to perform re-computation can prevent faulty implementations.
+The envelope payload MUST be detached, and recomputed by the verifier.
 
 One example of a Signed Inclusion Proof is a "transparent statement" as defined in {{-scitt-architecture}}.
 
-## Inclusion Paths
+~~~~
+# COSE_Sign1
+18([
 
-{{-certificate-transparency-v1}} defines a merkle audit path for a leaf in a merkle tree
-as the shortest list of additional nodes in the merkle tree required to compute the merkle root for that tree.
+  # Protected Header
+  h'a2012604588368747470733a2f2f73636974742e78797a2f75726e3a696574663a706172616d733a7472616e733a696e636c7573696f6e3a726663393136325f7368613235363a303a65343263333764326638306361613464323035353635376534303463386538363838313534346136663264313731356530663564616435643436343833633531', 
+  # {
+  #   "alg" : "ES256",
+  #   1 : -7,
+  #   "tree_alg" : "RFC9162_SHA256",
+  #   TBD_1 : 1,
+  # }
 
-{{-certificate-transparency-v2}} changed the term from "merkle audit path" to "merkle inclusion proof".
+  # Unprotected Header
+  {
+      # "inclusion-proof" : "h'3133312c322c302c3132392c3231362c36342c38382c33322c3235342c3132382c33392c34392c3131382c312c3230352c38372c3235332c3136312c31332c3136312c38352c3139302c3133322c3234312c3137332c34352c3132372c32302c35302c35342c31332c3134342c33332c3233372c3234382c3132382c32332c3138392c3133352c3932'"    
+      TBD_2 : h'3133312c322c302c3132392c3231362c36342c38382c33322c3235342c3132382c33392c34392c3131382c312c3230352c38372c3235332c3136312c31332c3136312c38352c3139302c3133322c3234312c3137332c34352c3132372c32302c35302c35342c31332c3134342c33332c3233372c3234382c3132382c32332c3138392c3133352c3932' 
+  },
 
-We prefer to use the term "inclusion path" to avoid confusion with Signed Inclusion Proof.
+  # Detached Payload
 
-Editors note: We may want to move inclusion path representations to the specification that is required to register a new algorithm in the proposed tree algorithms registry.
-
-Editors note: We recommend tree algorithm simple take the inclusion path as opaque bytes.
-
-If the tree size and leaf index is known, then a compact inclusion path variant can be used:
-
-~~~~ cddl
-index-aware-inclusion-path = #6.1234([
-    tree-size: int
-    leaf-index: int
-    hashes: [+ bstr]
+  # Signature
+  h'4862c1dced27ceeb1f7a6277d13be127a8969a7171ae000ffa90ef5757b817ca8ee61d57645d1a087251a97f06eb61aec46ecf958e4a0fb94ae37f410c7f77ea'
 ])
 ~~~~
 
-Leaf index is also sometimes referred to as sequence number.
-
-Otherwise, the direction each path step must be included:
-
-FIXME bit vector: 0 right, 1 left, so no bit labels
-
-~~~~ cddl
-index-unaware-inclusion-path = #6.1235([
-    hashes: [+ bstr]
-    left: uint  ; bit vector
-])
-~~~~
-
-For some tree algorithms, the direction is derived from the hashes themselves and both the index and direction can be left out in the path:
-
-~~~~ cddl
-sorted-inclusion-proof = #6.1236([+ bstr])
-~~~~
-
-~~~~ cddl
-inclusion-path = index-aware-inclusion-path / index-unaware-inclusion-path / sorted-inclusion-proof
-~~~~
-
-Presence of leaf index, and whether it is an input or an output is tree algorithm specific.
-
-## Inclusion Proof
-
-An inclusion proof is a CBOR array containing a merkle tree root, an inclusion path, extra data for the tree algorithm, and the payload.
-
-~~~~ cddl
-inclusion-proof = [
-  merkle-tree-root: bstr ;
-  inclusion-path: bstr .cbor inclusion-path
-  extra-data: bstr / nil
-  leaf-payload: bstr ;
-]
-~~~~
-
-## Signed Inclusion Proof
-
-A signed inclusion proof is a CBOR array containing a signed tree root, an inclusion path, extra data for the tree algorithm, and the payload.
+### Array form CDDL
 
 ~~~~ cddl
 signed-inclusion-proof = [
-  signed-tree-root: bstr .cbor smtr ; payload of COSE_Sign1_Tagged is detached
-  inclusion-path: bstr .cbor inclusion-path
-  extra-data: bstr / nil
-  leaf-payload: bstr ; leaf payload, not payload in signed_tree_root, could be detached.
+  signed-inclusion-proof: bstr .cbor smtr ; the payload is a merkle root, as described by the tree algorithm, and is detached.
+  inclusion-proof: bstr .cbor inclusion-proof ; the inclusion-proof, as described in the tree algorithm
+  leaf: bstr ; the leaf, as described in the tree algorithm
 ]
 ~~~~
 
-`extra-data` is an additional input to the tree algorithm and is used together with the payload to compute the leaf hash. See {{sec-leaf-blinding-example}} for an example use case for this field to enable leaf blinding as described in
-{{sec-leaf-blinding}}.
+## Signed Consistency Proof
 
-## Signed Multiple Inclusion Proofs
+~~~~
+# COSE_Sign1
+18([
 
-### Sorted Hashes Multiproof
+  # Protected Header
+  h'a2012604588568747470733a2f2f73636974742e78797a2f75726e3a696574663a706172616d733a7472616e733a636f6e73697374656e63793a726663393136325f7368613235363a303a66653830323733313736303163643537666461313064613135356265383466316164326437663134333233363064393032316564663838303137626438373563', 
+  # {
+  #   "alg" : "ES256",
+  #   1 : -7,
+  #   "tree_alg" : "RFC9162_SHA256",
+  #   TBD_1 : 1,
+  # }
 
-This signed mulitple inclusion proof representation relies on 2 lists to enable proof of inclusion for multiple payloads in a given signed merkle root.
+  # Unprotected Header
+  {
+      # "consistency-proof" : "h'3133312c312c312c3132392c3231362c36342c38382c33322c3235342c3132382c33392c34392c3131382c312c3230352c38372c3235332c3136312c31332c3136312c38352c3139302c3133322c3234312c3137332c34352c3132372c32302c35302c35342c31332c3134342c33332c3233372c3234382c3132382c32332c3138392c3133352c3932'"    
+      TBD_3 : h'3133312c312c312c3132392c3231362c36342c38382c33322c3235342c3132382c33392c34392c3131382c312c3230352c38372c3235332c3136312c31332c3136312c38352c3139302c3133322c3234312c3137332c34352c3132372c32302c35302c35342c31332c3134342c33332c3233372c3234382c3132382c32332c3138392c3133352c3932' 
+  },
 
-Note that the extra-data may be ommited if not required by the tree algorithm, and that leaf payloads may be detached.
+  # Protected Payload
+  h'fe8027317601cd57fda10da155be84f1ad2d7f1432360d9021edf88017bd875c',
+
+  # Signature
+  h'fe476fcddb783805fe344fc96837f4a5531c2e5a56d6f6353831e84e17ac69d4407a5a0d6eadf27f3a570bcf604181fd11b4692d3ac17b116c6226ba43726113'
+])
+~~~~
+
+### Array form CDDL
 
 ~~~~ cddl
-signed-multiple-inclusion-proof = [
-  signed-tree-root: bstr .cbor smtr ; payload of COSE_Sign1_Tagged is detached
-  inclusion-paths: [+ [ bstr / nil .cbor extra-data, bstr .cbor inclusion-path] ]
-  leaf-payloads: [+ bstr] ; leaf payloads, could be detached.
+signed-consistency-proof = [
+  signed-consistency-proof: bstr .cbor smtr ; the payload is a merkle root, as described by the tree algorithm, and is *attached*.
+  consistency-proof: bstr .cbor consistency-proof ; the consistency-proof, as described in the tree algorithm
 ]
 ~~~~
-
-TODO: refine multi-leaf variant of a signed inclusion proof like in:
-
-* https://github.com/transmute-industries/merkle-proof
-* https://transmute-industries.github.io/merkle-disclosure-proof-2021/
-
-TODO: consider using sparse multiproofs, see https://medium.com/@jgm.orinoco/understanding-sparse-merkle-multiproofs-9b9f049e8f08 and https://arxiv.org/pdf/2002.07648.pdf
 
 # Merkle Tree Algorithms {#sec-merkle-tree-algorithms}
 
 This document establishes a registry of merkle tree algorithms with the following initial contents:
-
 
 | Identifier            | Tree Algorithm | Reference
 |---
@@ -270,20 +269,94 @@ This document establishes a registry of merkle tree algorithms with the followin
 |1 | RFC9162_SHA256     | {{-certificate-transparency-v2}}
 {: #merkle-tree-alg-values align="left" title="Merke Tree Alogrithms"}
 
-Each tree algorithm defines how to compute the root node from a sequence of leaves each represented by payload and extra data. Extra data is algorithm-specific and should be considered opaque.
+Each tree algorithm defines:
+
+0. How to compute a leaf from a payload and extra data, such as the current size of the tree.
+1. How to compute the merkle root from a sequence of leaves.
+2. How to compute an inclusion-proof for a leaf.
+3. How to compute a consistency-proof for a leaf.
+
+Each specification MUST define how to encode each of these parameters in CBOR, and map them to:
+
+- TBD_1 - (tree alg)
+- TBD_2 - (inclusion proof)
+- TBD_3 - (consistency proof)
+
+See {{sec-rfc-9162-tree-alg-definition}} as an example.
+
+## The RFC9162_SHA256 Tree Algorithm {#sec-rfc-9162-tree-alg-definition}
+
+This section defines how to map the data structures described in {{-certificate-transparency-v2}} 
+to the terminology defined in this document, using cbor and cose.
+
+### Tree Algorithm
+
+The integer identifier for "tree-alg" is 1.
+The string identifier for "tree-alg" is "RFC9162_SHA256".
+
+### Tree Definition
+
+See {{-certificate-transparency-v2}}, 2.1.1. Definition of the Merkle Tree.
+
+#### Merkle Root
+
+The cbor representation of a merkle root is the bytestring represenation of MTH.
+
+#### Inclusion Proof
+
+See {{-certificate-transparency-v2}}, 2.1.3.1. Generating an Inclusion Proof.
+
+The cbor representation of the inclusion proof is:
+
+~~~~ cddl
+inclusion-proof = #6.1234([
+    tree-size: int
+    leaf-index: int
+    inclusion-path: [+ bstr]
+])
+~~~~
+
+#### Consistency Proof
+
+See {{-certificate-transparency-v2}}, 2.1.4.1. Generating a Consistency Proof.
+
+The cbor representation of the consistency proof is:
+
+~~~~ cddl
+consistency-proof = #6.1234([
+    tree-size-1: int ; size of the tree, when the previous root was produced.
+    tree-size-2: int ; size of the tree, when the latest root was produced.
+    consistency-path: [+ bstr] ; consistency path, from previous root to latest root.
+])
+~~~~
+
+Editors note: tree-size-1, could be ommited, if an inclusion-proof is always present, since the inclusion proof contains, tree-size-1.
+
+## Signed Proofs
+
+In a signed inclusion proof, the previous merkle tree root, maps to tree-size-1, and is a detached payload.
+In a signed consistency proof, the latest merkle tree root, maps to tree-size-2, and is an attached payload.
 
 # Privacy Considerations
 
-TBD
+See the privacy considerations section of:
+
+- {{-certificate-transparency-v2}}
+- {{-cose}}
 
 ## Leaf Blinding {#sec-leaf-blinding}
 
 In cases where a single merkle root and multiple inclusion paths are used to prove inclusion for multiple payloads. There is a risk that an attacker may be able to learn the content of undisclosed payloads, by brute forcing the values adjacent to the disclosed payloads through application of the cryptographic hash function and comparison to the the disclosed inclusion paths. This kind of attack can be mitigated by including a cryptographic nonce in the construction of the leaf, however this nonce must then disclosed along side an inclusion proof which increases the size of multiple payload signed inclusion proofs.
 
+Tree algorithm designers are encouraged to comment on this property of their leaf construction algorithm.
+
 
 # Security Considerations
 
-TBD
+See the privacy considerations section of:
+
+- {{-certificate-transparency-v2}}
+- {{-cose}}
 
 ## Hash Function Agility
 
@@ -295,19 +368,30 @@ The choice of cryptographic hash function is the primary primitive impacting the
 
 ### New Entries to the COSE Header Parameters Registry
 
-IANA will be requested to register the new COSE Header parameters defined below in the "COSE Header Parameters" registry at some point.
+This document requests IANA to add new values to the 'COSE
+Algorithms' and to the 'COSE Header Algorithm Parameters' registries
+in the 'Standards Action With Expert Review category.
+
+#### COSE Header Algorithm Parameters
 
 * Name: tree_alg
-* Label: TBD
+* Label: TBD_1
 * Value type: tree_alg
 * Value registry: See {{tree-alg-registry}}
 * Description: Merkle tree algorithm used to produce a COSE Sign1 payload.
 
-## New SCITT-Related Registries
+* Name: inclusion_proof
+* Label: TBD_2
+* Value type: inclusion_proof
+* Value registry: See {{tree-alg-registry}}
+* Description: Merkle tree inclusion proof for the given tree_alg.
 
-IANA will be asked to add a new registry "TBD" to the list that appears at [IANA Assignments](https://www.iana.org/assignments/).
+* Name: consistency_proof
+* Label: TBD_2
+* Value type: consistency_proof
+* Value registry: See {{tree-alg-registry}}
+* Description: Merkle tree consistency proof for the given tree_alg.
 
-The rest of this section defines the subregistries that are to be created within the new "TBD" registry.
 
 ### Tree Algorithms {#tree-alg-registry}
 
@@ -322,21 +406,6 @@ Template:
 Initial contents: Provided in {{merkle-tree-alg-values}}
 
 --- back
-
-# Example Tree Algorithms
-
-## RFC9162_SHA256
-
-The `RFC9162_SHA256` tree algorithm uses the merkle tree definition from {{-certificate-transparency-v2}} with SHA-256 hash algorithm.
-
-For n > 1 inputs, let k be the largest power of two smaller than n.
-
-~~~~
-MTH({d(0)}) = SHA-256(0x00 || d(0))
-MTH(D[n]) = SHA-256(0x01 || MTH(D[0:k]) || MTH(D[k:n]))
-~~~~
-
-where `d(0)` is the payload. By default this algorithm takes no extra data.
 
 ### Blinding Example {#sec-leaf-blinding-example}
 


### PR DESCRIPTION
These changes focus this draft on the minimal definitions required to secure the data structures defined in RFC9162 using CBOR and COSE.

Extraneous information has been removed.

There is a wip implementation available here: 

- https://github.com/transmute-industries/cose

There is a demo here:

- https://scitt.xyz